### PR TITLE
Feat: 탭바 컨트롤러 구현

### DIFF
--- a/NewsBee.xcodeproj/project.pbxproj
+++ b/NewsBee.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = BA21343728505B3F00E3D332 /* NewsBee.xcdatamodeld */; };
 		BA21343B28505B4000E3D332 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BA21343A28505B4000E3D332 /* Assets.xcassets */; };
 		BA21343E28505B4000E3D332 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BA21343C28505B4000E3D332 /* LaunchScreen.storyboard */; };
+		BADCD7A2285076BA009E0CD0 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A1285076BA009E0CD0 /* HomeViewController.swift */; };
+		BADCD7A4285076C2009E0CD0 /* PopularViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A3285076C2009E0CD0 /* PopularViewController.swift */; };
+		BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A528507706009E0CD0 /* SearchViewController.swift */; };
+		BADCD7A828507745009E0CD0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A728507745009E0CD0 /* SettingsViewController.swift */; };
+		BADCD7AA28507799009E0CD0 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A928507799009E0CD0 /* AlertViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +30,11 @@
 		BA21343D28505B4000E3D332 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BA21343F28505B4000E3D332 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		BA21344528505E1A00E3D332 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		BADCD7A1285076BA009E0CD0 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
+		BADCD7A3285076C2009E0CD0 /* PopularViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularViewController.swift; sourceTree = "<group>"; };
+		BADCD7A528507706009E0CD0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
+		BADCD7A728507745009E0CD0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
+		BADCD7A928507799009E0CD0 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,9 +82,22 @@
 		BADCD79F285075D1009E0CD0 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				BA21343228505B3F00E3D332 /* MainTabBarViewController.swift */,
+				BADCD7A028507688009E0CD0 /* ViewControllers */,
 			);
 			path = Source;
+			sourceTree = "<group>";
+		};
+		BADCD7A028507688009E0CD0 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				BADCD7A1285076BA009E0CD0 /* HomeViewController.swift */,
+				BADCD7A3285076C2009E0CD0 /* PopularViewController.swift */,
+				BADCD7A528507706009E0CD0 /* SearchViewController.swift */,
+				BADCD7A928507799009E0CD0 /* AlertViewController.swift */,
+				BADCD7A728507745009E0CD0 /* SettingsViewController.swift */,
+				BA21343228505B3F00E3D332 /* MainTabBarViewController.swift */,
+			);
+			path = ViewControllers;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -152,9 +175,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA21343328505B3F00E3D332 /* MainTabBarViewController.swift in Sources */,
+				BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */,
 				BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */,
 				BA21342F28505B3F00E3D332 /* AppDelegate.swift in Sources */,
+				BADCD7AA28507799009E0CD0 /* AlertViewController.swift in Sources */,
+				BADCD7A2285076BA009E0CD0 /* HomeViewController.swift in Sources */,
+				BADCD7A4285076C2009E0CD0 /* PopularViewController.swift in Sources */,
 				BA21343128505B3F00E3D332 /* SceneDelegate.swift in Sources */,
+				BADCD7A828507745009E0CD0 /* SettingsViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/NewsBee.xcodeproj/project.pbxproj
+++ b/NewsBee.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		BA21342F28505B3F00E3D332 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA21342E28505B3F00E3D332 /* AppDelegate.swift */; };
 		BA21343128505B3F00E3D332 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA21343028505B3F00E3D332 /* SceneDelegate.swift */; };
-		BA21343328505B3F00E3D332 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA21343228505B3F00E3D332 /* ViewController.swift */; };
+		BA21343328505B3F00E3D332 /* MainTabBarViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA21343228505B3F00E3D332 /* MainTabBarViewController.swift */; };
 		BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = BA21343728505B3F00E3D332 /* NewsBee.xcdatamodeld */; };
 		BA21343B28505B4000E3D332 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BA21343A28505B4000E3D332 /* Assets.xcassets */; };
 		BA21343E28505B4000E3D332 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BA21343C28505B4000E3D332 /* LaunchScreen.storyboard */; };
@@ -19,7 +19,7 @@
 		BA21342B28505B3F00E3D332 /* NewsBee.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NewsBee.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BA21342E28505B3F00E3D332 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BA21343028505B3F00E3D332 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
-		BA21343228505B3F00E3D332 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		BA21343228505B3F00E3D332 /* MainTabBarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarViewController.swift; sourceTree = "<group>"; };
 		BA21343828505B3F00E3D332 /* NewsBee.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = NewsBee.xcdatamodel; sourceTree = "<group>"; };
 		BA21343A28505B4000E3D332 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		BA21343D28505B4000E3D332 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -60,13 +60,21 @@
 			children = (
 				BA21342E28505B3F00E3D332 /* AppDelegate.swift */,
 				BA21343028505B3F00E3D332 /* SceneDelegate.swift */,
-				BA21343228505B3F00E3D332 /* ViewController.swift */,
+				BADCD79F285075D1009E0CD0 /* Source */,
 				BA21343A28505B4000E3D332 /* Assets.xcassets */,
 				BA21343C28505B4000E3D332 /* LaunchScreen.storyboard */,
 				BA21343F28505B4000E3D332 /* Info.plist */,
 				BA21343728505B3F00E3D332 /* NewsBee.xcdatamodeld */,
 			);
 			path = NewsBee;
+			sourceTree = "<group>";
+		};
+		BADCD79F285075D1009E0CD0 /* Source */ = {
+			isa = PBXGroup;
+			children = (
+				BA21343228505B3F00E3D332 /* MainTabBarViewController.swift */,
+			);
+			path = Source;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -85,6 +93,8 @@
 			dependencies = (
 			);
 			name = NewsBee;
+			packageProductDependencies = (
+			);
 			productName = NewsBee;
 			productReference = BA21342B28505B3F00E3D332 /* NewsBee.app */;
 			productType = "com.apple.product-type.application";
@@ -113,6 +123,8 @@
 				Base,
 			);
 			mainGroup = BA21342228505B3F00E3D332;
+			packageReferences = (
+			);
 			productRefGroup = BA21342C28505B3F00E3D332 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -139,7 +151,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				BA21343328505B3F00E3D332 /* ViewController.swift in Sources */,
+				BA21343328505B3F00E3D332 /* MainTabBarViewController.swift in Sources */,
 				BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */,
 				BA21342F28505B3F00E3D332 /* AppDelegate.swift in Sources */,
 				BA21343128505B3F00E3D332 /* SceneDelegate.swift in Sources */,

--- a/NewsBee/SceneDelegate.swift
+++ b/NewsBee/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window?.windowScene = windowScene
     
     // 4. rootviewController 설정
-    let vc = ViewController()
+    let vc = MainTabBarViewController()
     window?.rootViewController = vc
     
     // 5. 설정한 window를 띄워줌

--- a/NewsBee/Source/MainTabBarViewController.swift
+++ b/NewsBee/Source/MainTabBarViewController.swift
@@ -7,11 +7,11 @@
 
 import UIKit
 
-class ViewController: UIViewController {
+class MainTabBarViewController: UITabBarController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .yellow
+    view.backgroundColor = .systemPink
   }
 
 

--- a/NewsBee/Source/ViewControllers/AlertViewController.swift
+++ b/NewsBee/Source/ViewControllers/AlertViewController.swift
@@ -1,0 +1,16 @@
+//
+//  AlertViewController.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/08.
+//
+
+import UIKit
+
+class AlertViewController: UIViewController {
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+  }
+}

--- a/NewsBee/Source/ViewControllers/HomeViewController.swift
+++ b/NewsBee/Source/ViewControllers/HomeViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ViewController.swift
+//  HomeViewController.swift
 //  NewsBee
 //
 //  Created by 홍승현 on 2022/06/08.
@@ -7,13 +7,10 @@
 
 import UIKit
 
-class MainTabBarViewController: UITabBarController {
-
+class HomeViewController: UIViewController {
+  
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .systemPink
+    view.backgroundColor = .systemBackground
   }
-
-
 }
-

--- a/NewsBee/Source/ViewControllers/MainTabBarViewController.swift
+++ b/NewsBee/Source/ViewControllers/MainTabBarViewController.swift
@@ -11,7 +11,7 @@ class MainTabBarViewController: UITabBarController {
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    view.backgroundColor = .systemPink
+    view.backgroundColor = .black
     
     
     let vc1 = UINavigationController(rootViewController: HomeViewController())
@@ -33,7 +33,9 @@ class MainTabBarViewController: UITabBarController {
     vc4.title = "알림"
     vc5.title = "설정"
     
-    tabBar.tintColor = .label
+    tabBar.tintColor = .white
+    tabBar.barTintColor = .white
+    tabBar.isTranslucent = false
     
     setViewControllers([vc1, vc2, vc3, vc4, vc5], animated: true)
     

--- a/NewsBee/Source/ViewControllers/MainTabBarViewController.swift
+++ b/NewsBee/Source/ViewControllers/MainTabBarViewController.swift
@@ -1,0 +1,47 @@
+//
+//  MainTabBarViewController.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/08.
+//
+
+import UIKit
+
+class MainTabBarViewController: UITabBarController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemPink
+    
+    
+    let vc1 = UINavigationController(rootViewController: HomeViewController())
+    let vc2 = UINavigationController(rootViewController: PopularViewController())
+    let vc3 = UINavigationController(rootViewController: SearchViewController())
+    let vc4 = UINavigationController(rootViewController: AlertViewController())
+    let vc5 = UINavigationController(rootViewController: SettingsViewController())
+    
+    
+    vc1.tabBarItem.image = UIImage(systemName: "newspaper")
+    vc2.tabBarItem.image = UIImage(systemName: "star")
+    vc3.tabBarItem.image = UIImage(systemName: "magnifyingglass")
+    vc4.tabBarItem.image = UIImage(systemName: "bell")
+    vc5.tabBarItem.image = UIImage(systemName: "gearshape")
+    
+    vc1.title = "뉴스"
+    vc2.title = "인기"
+    vc3.title = "검색"
+    vc4.title = "알림"
+    vc5.title = "설정"
+    
+    tabBar.tintColor = .label
+    
+    setViewControllers([vc1, vc2, vc3, vc4, vc5], animated: true)
+    
+    
+    
+    
+  }
+
+
+}
+

--- a/NewsBee/Source/ViewControllers/PopularViewController.swift
+++ b/NewsBee/Source/ViewControllers/PopularViewController.swift
@@ -1,0 +1,16 @@
+//
+//  PopularViewController.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/08.
+//
+
+import UIKit
+
+class PopularViewController: UIViewController {
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+  }
+}

--- a/NewsBee/Source/ViewControllers/SearchViewController.swift
+++ b/NewsBee/Source/ViewControllers/SearchViewController.swift
@@ -1,0 +1,16 @@
+//
+//  SearchViewController.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/08.
+//
+
+import UIKit
+
+class SearchViewController: UIViewController {
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+  }
+}

--- a/NewsBee/Source/ViewControllers/SettingsViewController.swift
+++ b/NewsBee/Source/ViewControllers/SettingsViewController.swift
@@ -1,0 +1,16 @@
+//
+//  SettingsViewController.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/08.
+//
+
+import UIKit
+
+class SettingsViewController: UIViewController {
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .systemBackground
+  }
+}


### PR DESCRIPTION
## 구현 사항

- storyboard 제거
- rootViewController로 tabbar 구현
- 5 개의 `tab bar`구성
   - 각 `뉴스`, `인기`, `검색`, `알림`, `설정` 순


<img src="https://user-images.githubusercontent.com/57972338/172603707-6292c9ef-9286-448f-8ecf-858b1148399d.gif" width="40%" height="40%"/>


## 관련 이슈

- #1 

## 추가 의견

- 없음
