### PR TITLE
서버 통신 작업 진행

### DIFF
--- a/NewsBee.xcodeproj/project.pbxproj
+++ b/NewsBee.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		BADCD7A828507745009E0CD0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A728507745009E0CD0 /* SettingsViewController.swift */; };
 		BADCD7AA28507799009E0CD0 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A928507799009E0CD0 /* AlertViewController.swift */; };
 		BAE326592864624E009F28F2 /* MyNewsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE326582864624E009F28F2 /* MyNewsInfo.swift */; };
+		BAE3265B28646369009F28F2 /* SocketConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE3265A28646369009F28F2 /* SocketConnection.swift */; };
 		BAE77C50285474E9007330B0 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE77C4F285474E9007330B0 /* APIConstants.swift */; };
 /* End PBXBuildFile section */
 
@@ -60,6 +61,7 @@
 		BADCD7A728507745009E0CD0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		BADCD7A928507799009E0CD0 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		BAE326582864624E009F28F2 /* MyNewsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNewsInfo.swift; sourceTree = "<group>"; };
+		BAE3265A28646369009F28F2 /* SocketConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketConnection.swift; sourceTree = "<group>"; };
 		BAE77C4F285474E9007330B0 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -205,6 +207,7 @@
 			children = (
 				BAE77C4F285474E9007330B0 /* APIConstants.swift */,
 				BA949027285B0E1C00AC71EF /* APICaller.swift */,
+				BAE3265A28646369009F28F2 /* SocketConnection.swift */,
 				BA94902E285B257600AC71EF /* APINewsURI.swift */,
 				BA949029285B129100AC71EF /* APIError.swift */,
 			);
@@ -291,6 +294,7 @@
 				BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */,
 				BA94902A285B129100AC71EF /* APIError.swift in Sources */,
 				BA54D3F0285F5B73001F068C /* NewsTableViewCellViewModel.swift in Sources */,
+				BAE3265B28646369009F28F2 /* SocketConnection.swift in Sources */,
 				BA94902D285B1D3600AC71EF /* Observable.swift in Sources */,
 				BA92985328536E4400DD9364 /* NewsViewController.swift in Sources */,
 				BA0BA8122855E174008DF038 /* NewsTableViewCell.swift in Sources */,

--- a/NewsBee.xcodeproj/project.pbxproj
+++ b/NewsBee.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A528507706009E0CD0 /* SearchViewController.swift */; };
 		BADCD7A828507745009E0CD0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A728507745009E0CD0 /* SettingsViewController.swift */; };
 		BADCD7AA28507799009E0CD0 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A928507799009E0CD0 /* AlertViewController.swift */; };
-		BAE326592864624E009F28F2 /* MyNewsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE326582864624E009F28F2 /* MyNewsInfo.swift */; };
+		BAE326592864624E009F28F2 /* ServerNewsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE326582864624E009F28F2 /* ServerNewsInfo.swift */; };
 		BAE3265B28646369009F28F2 /* SocketConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE3265A28646369009F28F2 /* SocketConnection.swift */; };
 		BAE77C50285474E9007330B0 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE77C4F285474E9007330B0 /* APIConstants.swift */; };
 /* End PBXBuildFile section */
@@ -62,7 +62,7 @@
 		BADCD7A528507706009E0CD0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		BADCD7A728507745009E0CD0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		BADCD7A928507799009E0CD0 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
-		BAE326582864624E009F28F2 /* MyNewsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNewsInfo.swift; sourceTree = "<group>"; };
+		BAE326582864624E009F28F2 /* ServerNewsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerNewsInfo.swift; sourceTree = "<group>"; };
 		BAE3265A28646369009F28F2 /* SocketConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketConnection.swift; sourceTree = "<group>"; };
 		BAE77C4F285474E9007330B0 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -143,7 +143,7 @@
 			isa = PBXGroup;
 			children = (
 				BA949025285B0DDE00AC71EF /* NewsInfo.swift */,
-				BAE326582864624E009F28F2 /* MyNewsInfo.swift */,
+				BAE326582864624E009F28F2 /* ServerNewsInfo.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -292,7 +292,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA21343328505B3F00E3D332 /* MainTabBarViewController.swift in Sources */,
-				BAE326592864624E009F28F2 /* MyNewsInfo.swift in Sources */,
+				BAE326592864624E009F28F2 /* ServerNewsInfo.swift in Sources */,
 				BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */,
 				BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */,
 				BA94902A285B129100AC71EF /* APIError.swift in Sources */,

--- a/NewsBee.xcodeproj/project.pbxproj
+++ b/NewsBee.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		BA94902F285B257600AC71EF /* APINewsURI.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA94902E285B257600AC71EF /* APINewsURI.swift */; };
 		BA949031285B6E6300AC71EF /* NewsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA949030285B6E6300AC71EF /* NewsListViewModel.swift */; };
 		BA9B7EC028577CA700BF69B1 /* NewsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA9B7EBF28577CA700BF69B1 /* NewsHeaderView.swift */; };
+		BABFC9072864657500AF8B04 /* ServerNewsHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABFC9062864657500AF8B04 /* ServerNewsHeader.swift */; };
 		BADCD7A2285076BA009E0CD0 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A1285076BA009E0CD0 /* HomeViewController.swift */; };
 		BADCD7A4285076C2009E0CD0 /* PopularViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A3285076C2009E0CD0 /* PopularViewController.swift */; };
 		BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A528507706009E0CD0 /* SearchViewController.swift */; };
@@ -55,6 +56,7 @@
 		BA94902E285B257600AC71EF /* APINewsURI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APINewsURI.swift; sourceTree = "<group>"; };
 		BA949030285B6E6300AC71EF /* NewsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsListViewModel.swift; sourceTree = "<group>"; };
 		BA9B7EBF28577CA700BF69B1 /* NewsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsHeaderView.swift; sourceTree = "<group>"; };
+		BABFC9062864657500AF8B04 /* ServerNewsHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerNewsHeader.swift; sourceTree = "<group>"; };
 		BADCD7A1285076BA009E0CD0 /* HomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewController.swift; sourceTree = "<group>"; };
 		BADCD7A3285076C2009E0CD0 /* PopularViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PopularViewController.swift; sourceTree = "<group>"; };
 		BADCD7A528507706009E0CD0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
@@ -209,6 +211,7 @@
 				BA949027285B0E1C00AC71EF /* APICaller.swift */,
 				BAE3265A28646369009F28F2 /* SocketConnection.swift */,
 				BA94902E285B257600AC71EF /* APINewsURI.swift */,
+				BABFC9062864657500AF8B04 /* ServerNewsHeader.swift */,
 				BA949029285B129100AC71EF /* APIError.swift */,
 			);
 			path = Network;
@@ -298,6 +301,7 @@
 				BA94902D285B1D3600AC71EF /* Observable.swift in Sources */,
 				BA92985328536E4400DD9364 /* NewsViewController.swift in Sources */,
 				BA0BA8122855E174008DF038 /* NewsTableViewCell.swift in Sources */,
+				BABFC9072864657500AF8B04 /* ServerNewsHeader.swift in Sources */,
 				BA949031285B6E6300AC71EF /* NewsListViewModel.swift in Sources */,
 				BA21342F28505B3F00E3D332 /* AppDelegate.swift in Sources */,
 				BA9B7EC028577CA700BF69B1 /* NewsHeaderView.swift in Sources */,

--- a/NewsBee.xcodeproj/project.pbxproj
+++ b/NewsBee.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A528507706009E0CD0 /* SearchViewController.swift */; };
 		BADCD7A828507745009E0CD0 /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A728507745009E0CD0 /* SettingsViewController.swift */; };
 		BADCD7AA28507799009E0CD0 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADCD7A928507799009E0CD0 /* AlertViewController.swift */; };
+		BAE326592864624E009F28F2 /* MyNewsInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE326582864624E009F28F2 /* MyNewsInfo.swift */; };
 		BAE77C50285474E9007330B0 /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAE77C4F285474E9007330B0 /* APIConstants.swift */; };
 /* End PBXBuildFile section */
 
@@ -58,6 +59,7 @@
 		BADCD7A528507706009E0CD0 /* SearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewController.swift; sourceTree = "<group>"; };
 		BADCD7A728507745009E0CD0 /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		BADCD7A928507799009E0CD0 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
+		BAE326582864624E009F28F2 /* MyNewsInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyNewsInfo.swift; sourceTree = "<group>"; };
 		BAE77C4F285474E9007330B0 /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -137,6 +139,7 @@
 			isa = PBXGroup;
 			children = (
 				BA949025285B0DDE00AC71EF /* NewsInfo.swift */,
+				BAE326582864624E009F28F2 /* MyNewsInfo.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -283,6 +286,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA21343328505B3F00E3D332 /* MainTabBarViewController.swift in Sources */,
+				BAE326592864624E009F28F2 /* MyNewsInfo.swift in Sources */,
 				BADCD7A628507706009E0CD0 /* SearchViewController.swift in Sources */,
 				BA21343928505B3F00E3D332 /* NewsBee.xcdatamodeld in Sources */,
 				BA94902A285B129100AC71EF /* APIError.swift in Sources */,

--- a/NewsBee/Resource/Network/APICaller.swift
+++ b/NewsBee/Resource/Network/APICaller.swift
@@ -45,7 +45,7 @@ struct APICaller: SocketConnection {
     task.resume()
   }
   
-  func serverNews(header: ServerNewsHeader, completion: @escaping (Result<[MyNewsInfo], APIError>) -> Void) {
+  func serverNews(header: ServerNewsHeader, completion: @escaping (Result<[ServerNewsInfo], APIError>) -> Void) {
     guard let percentString = header.percentQuery,
           let url = URL(string: "http://\(hostAddress):\(port)/\(percentString)")
     else {
@@ -68,7 +68,7 @@ struct APICaller: SocketConnection {
       }
       
       do {
-        let results = try JSONDecoder().decode([MyNewsInfo].self, from: data)
+        let results = try JSONDecoder().decode([ServerNewsInfo].self, from: data)
         completion(.success(results))
       
       } catch {

--- a/NewsBee/Resource/Network/APICaller.swift
+++ b/NewsBee/Resource/Network/APICaller.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// 네이버 뉴스 API를 가져올 때 사용합니다.
-struct APICaller {
+struct APICaller: SocketConnection {
   
   /// 뉴스를 가져옵니다.
   func getNaverNews(header: APINewsURI, completion: @escaping (Result<ResponseNews, APIError>) -> Void) {
@@ -45,5 +45,37 @@ struct APICaller {
     task.resume()
   }
   
-  
+  func serverNews(header: ServerNewsHeader, completion: @escaping (Result<[MyNewsInfo], APIError>) -> Void) {
+    guard let percentString = header.percentQuery,
+          let url = URL(string: "http://\(hostAddress):\(port)/\(percentString)")
+    else {
+      completion(.failure(.responseError))
+      return
+    }
+    
+    var urlRequest = URLRequest(url: url)
+    urlRequest.addValue(String(header.startIndex), forHTTPHeaderField: "startIndex")
+    urlRequest.addValue(String(header.count), forHTTPHeaderField: "count")
+    
+    let task = URLSession.shared.dataTask(with: urlRequest) { data, response, error in
+      
+      guard let httpResponse = response as? HTTPURLResponse,
+            httpResponse.statusCode == 200,
+            let data = data
+      else {
+        completion(.failure(.responseError))
+        return
+      }
+      
+      do {
+        let results = try JSONDecoder().decode([MyNewsInfo].self, from: data)
+        completion(.success(results))
+      
+      } catch {
+        completion(.failure(.decodingError))
+      }
+    }
+    
+    task.resume()
+  }
 }

--- a/NewsBee/Resource/Network/ServerNewsHeader.swift
+++ b/NewsBee/Resource/Network/ServerNewsHeader.swift
@@ -1,0 +1,35 @@
+//
+//  ServerNewsHeader.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/23.
+//
+
+import Foundation
+
+
+/// 서버 뉴스 api에 대해 요청할 파라미터를 가집니다.
+struct ServerNewsHeader {
+  
+  /// 검색 쿼리
+  private let category: String
+  
+  /// 검색 결과 출력 건수 지정
+  let count: Int
+  
+  /// 검색 시작 위치
+  let startIndex: Int
+  
+  
+  /// 검색 쿼리를 url의 문자로 표현하는 쿼리문
+  var percentQuery: String? {
+    category.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
+  }
+  
+  init(category: String, count: Int = 10, startIndex: Int = 1) {
+    self.category = category
+    self.count = count
+    self.startIndex = startIndex
+  }
+  
+}

--- a/NewsBee/Resource/Network/ServerNewsHeader.swift
+++ b/NewsBee/Resource/Network/ServerNewsHeader.swift
@@ -26,7 +26,7 @@ struct ServerNewsHeader {
     category.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
   }
   
-  init(category: String, count: Int = 10, startIndex: Int = 1) {
+  init(category: String, count: Int = 20, startIndex: Int = 0) {
     self.category = category
     self.count = count
     self.startIndex = startIndex

--- a/NewsBee/Resource/Network/SocketConnection.swift
+++ b/NewsBee/Resource/Network/SocketConnection.swift
@@ -1,0 +1,30 @@
+//
+//  SocketConnection.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/23.
+//
+
+import Foundation
+
+protocol SocketConnection {
+  var port: Int { get }
+  var hostAddress: String { get }
+  
+  func connect(
+    _ category: String,
+    startIndex: Int,
+    count: Int,
+    completion: (Result<[MyNewsInfo], Error>) -> Void
+  )
+}
+
+extension SocketConnection {
+  var port: Int {
+    return 9999
+  }
+  
+  var hostAddress: String {
+    return "localhost"
+  }
+}

--- a/NewsBee/Resource/Network/SocketConnection.swift
+++ b/NewsBee/Resource/Network/SocketConnection.swift
@@ -10,13 +10,6 @@ import Foundation
 protocol SocketConnection {
   var port: Int { get }
   var hostAddress: String { get }
-  
-  func connect(
-    _ category: String,
-    startIndex: Int,
-    count: Int,
-    completion: (Result<[MyNewsInfo], Error>) -> Void
-  )
 }
 
 extension SocketConnection {

--- a/NewsBee/Source/Models/MyNewsInfo.swift
+++ b/NewsBee/Source/Models/MyNewsInfo.swift
@@ -1,0 +1,38 @@
+//
+//  MyNewsInfo.swift
+//  NewsBee
+//
+//  Created by 홍승현 on 2022/06/23.
+//
+
+import Foundation
+
+
+struct MyNewsInfo: Codable {
+  
+  /// 뉴스 제목
+  let title: String
+  
+  /// 뉴스의 내용 요약
+  let description: String
+  
+  /// 뉴스 이미지
+  let imageLink: String?
+  
+  /// 언론사 하이퍼텍스트 link
+  let url: String
+  
+  /// 뉴스 출판 시간
+  let publishDate: String
+  
+  
+  enum CodingKeys: String, CodingKey {
+    
+    case title
+    case description
+    case url
+    case imageLink = "image"
+    case publishDate = "date"
+  }
+  
+}

--- a/NewsBee/Source/Models/ServerNewsInfo.swift
+++ b/NewsBee/Source/Models/ServerNewsInfo.swift
@@ -1,5 +1,5 @@
 //
-//  MyNewsInfo.swift
+//  ServerNewsInfo.swift
 //  NewsBee
 //
 //  Created by 홍승현 on 2022/06/23.
@@ -8,7 +8,7 @@
 import Foundation
 
 
-struct MyNewsInfo: Codable {
+struct ServerNewsInfo: Codable {
   
   /// 뉴스 제목
   let title: String


### PR DESCRIPTION
## 구현 사항

- 서버와 iOS간 소켓통신하여 데이터를 주고받는 작업 수행

![화면 기록 2022-06-23 오후 7 00 25](https://user-images.githubusercontent.com/57972338/175273944-f83f166c-63a2-4f45-a9ee-8f11de6cc01a.gif)

- 네이버 뉴스와 서버뉴스 차이

|           |  네이버뉴스  |     서버뉴스     |
| :-------: | :----------: | :--------------: |
|   헤더    |  APINewsURI  | ServerNewsHeader |
| API메서드 | getNaverNews |    serverNews    |
| 리턴객체  | ResponseNews |  ServerNewsInfo  |

## 변경 사항

- 없음

## 관련 이슈

- #9

## 추가 의견

- 없음
